### PR TITLE
Fix BungeePermsAPI#userPrefix

### DIFF
--- a/src/main/java/net/alpenblock/bungeeperms/BungeePermsAPI.java
+++ b/src/main/java/net/alpenblock/bungeeperms/BungeePermsAPI.java
@@ -618,7 +618,7 @@ public class BungeePermsAPI
         if (u == null)
             return null;
 
-        return u.buildSuffix(server, world);
+        return u.buildPrefix(server, world);
     }
 
     /**


### PR DESCRIPTION
now correctly calls User#buildPrefix instead of User#buildSuffix